### PR TITLE
fix function call, there is no self

### DIFF
--- a/jsonapi/base/validators.py
+++ b/jsonapi/base/validators.py
@@ -260,7 +260,7 @@ def assert_resource_identifier_object(d, source_pointer="/"):
         )
 
     if "meta" in d:
-        self.assert_meta_object(d["meta"], source_pointer + "meta/")
+        assert_meta_object(d["meta"], source_pointer + "meta/")
 
     if not "type" in d:
         raise InvalidDocument(


### PR DESCRIPTION
Hi,
there's no `self` as it's a top-level function. I assume this is a leftover after refactoring or a copy-paste.