### PR TITLE
Fix broken setup.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ import sphinx_rtd_theme
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../../'))
 
-import jsonapi
+import jsonapi.version
 
 # -- General configuration ------------------------------------------------
 

--- a/jsonapi/__init__.py
+++ b/jsonapi/__init__.py
@@ -55,16 +55,3 @@ instance and pick only the ones you need.
 """
 
 # local
-from . import api
-from . import encoder
-from . import errors
-from . import handler
-from . import includer
-from . import pagination
-from . import request
-from . import response
-from . import response_builder
-from . import utilities
-from . import validation
-from . import validator
-from . import version

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 from setuptools import setup
 
 # local
-import jsonapi
+import jsonapi.version
 
 
 try:


### PR DESCRIPTION
Remove imports from `__init__.py` to avoid bug with not installed [cached_property](https://pypi.python.org/pypi/cached-property) dependency in setup.py. This dependency from request module is not installed at the moment of clean `python setup.py install` or `python setup.py egg_info`.

These changes of `__init__.py` may be backward incompatible with already existing projects based on `dev` branch of py-jsonapi (e.g. [py-jsonapi-flask](https://github.com/benediktschmitt/py-jsonapi-flask) or [py-jsonapi-sqlalchemy](https://github.com/benediktschmitt/py-jsonapi-sqlalchemy)). But explicit imports of py-jsonapi parts may be more clean decision in future, imho.
