### PR TITLE
Gives SQLAlchemy-backed APIs the same ability to define typenames (an…

### DIFF
--- a/jsonapi/sqlalchemy/schema.py
+++ b/jsonapi/sqlalchemy/schema.py
@@ -188,10 +188,10 @@ class Schema(jsonapi.base.schema.Schema):
         derived from the resource class.
     """
 
-    def __init__(self, resource_class):
+    def __init__(self, resource_class, typename=None):
         """
         """
-        super().__init__(resource_class)
+        super().__init__(resource_class, typename)
         self.find_sqlalchemy_markers()
         return None
 


### PR DESCRIPTION
I wanted to be able to user lowercase endpoints for uppercase classes.  The base schema allows this, but since the init() for an SQLAlchemy schema called super() without a typename, the default was used -- uppercase classes created uppercase endpoints.  This change keeps the current behavior if no typename is passed (since typename wasn't an argument to the SQLAlchemy schema init() previously), but uses the base schema's behavior if it is.